### PR TITLE
Add support for no "Description" data

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -344,41 +344,52 @@ UpdateManifest <- function() {
           x = pkg[['Package']]
         )
         # Process the description metadata
-        desc <- unlist(x = strsplit(x = pkg[['Description']], split = '\n'))
-        desc <- sapply(
-          X = strsplit(x = desc, split = ':'),
-          FUN = function(x) {
-            name <- trimws(x = x[[1]])
-            val <- trimws(x = unlist(x = strsplit(x = x[[2]], split = ',')))
-            val <- paste(val, collapse = ', ')
-            names(x = val) <- name
-            return(val)
-          }
-        )
-        desc <- sapply(
-          X = desc,
-          FUN = function(x) {
-            x <- tryCatch(
-              expr = as.numeric(x = x),
-              warning = function(...) {
-                return(x)
-              }
-            )
-            if (!is.numeric(x = x) && !is.na(x = as.logical(x = x))) {
-              x <- as.logical(x = x)
+        desc <- pkg[['Description']]
+        if (!is.na(desc)) {
+          desc <- unlist(x = strsplit(x = desc, split = '\n'))
+          desc <- sapply(
+            X = strsplit(x = desc, split = ':'),
+            FUN = function(x) {
+              name <- trimws(x = x[[1]])
+              val <- trimws(x = unlist(x = strsplit(x = x[[2]], split = ',')))
+              val <- paste(val, collapse = ', ')
+              names(x = val) <- name
+              return(val)
             }
-            return(x)
-          },
-          simplify = FALSE,
-          USE.NAMES = TRUE
-        )
+          )
+          desc <- sapply(
+            X = desc,
+            FUN = function(x) {
+              x <- tryCatch(
+                expr = as.numeric(x = x),
+                warning = function(...) {
+                  return(x)
+                }
+              )
+              if (!is.numeric(x = x) && !is.na(x = as.logical(x = x))) {
+                x <- as.logical(x = x)
+              }
+              return(x)
+            },
+            simplify = FALSE,
+            USE.NAMES = TRUE
+          )
+        }
         # Assemble the information
-        desc <- c(
-          'Dataset' = dataset,
-          'Version' = pkg[['Version']],
-          'Summary' = pkg[['Title']],
-          desc
-        )
+        if (is.na(desc)) {
+          desc <- c(
+            'Dataset' = dataset,
+            'Version' = pkg[['Version']],
+            'Summary' = pkg[['Title']]
+          )
+        } else {
+          desc <- c(
+            'Dataset' = dataset,
+            'Version' = pkg[['Version']],
+            'Summary' = pkg[['Title']],
+            desc
+          )
+        }
         return(desc)
       }
     )
@@ -393,8 +404,7 @@ UpdateManifest <- function() {
       }
     }
     # Convert each entry to a dataframe and bind everything together
-    avail.pkgs <- lapply(X = avail.pkgs, FUN = as.data.frame, stringsAsFactors = FALSE)
-    avail.pkgs <- do.call(what = 'rbind', args = avail.pkgs)
+    avail.pkgs <- as.data.frame(t(avail.pkgs))
     # Coerce version information to package_version
     avail.pkgs$Version <- package_version(x = avail.pkgs$Version)
   } else if (pkg.env$source == 'appdir') {


### PR DESCRIPTION
It seems that some data don't have "Description":

    % curl https://seurat.nygenome.org/src/contrib/PACKAGES | head
    1544
    Package: cbmc.SeuratData
    Version: 3.0.0
    Suggests: Seurat (>= 3.0.0)
    License: CC BY 4.0
    MD5sum: a622946afeb8ce86a8f8361ef350d92e
    NeedsCompilation: no

    Package: hcabm40k.SeuratData
    Version: 3.0.0
    Suggests: Seurat (>= 3.0.0)

It causes install failure:

    > devtools::install_github("satijalab/seurat-data")
    ...
    ** testing if installed package can be loaded from temporary location
    Error: package or namespace load failed for 'SeuratData':
     .onAttach failed in attachNamespace() for 'SeuratData', details:
      call: x[[2]]
      error: subscript out of bounds
    Error: loading failed
    Execution halted
    ERROR: loading failed
    ...
    > traceback()
    8: stop(remote_install_error(remotes[[i]], e))
    7: value[[3L]](cond)
    6: tryCatchOne(expr, names, parentenv, handlers[[1L]])
    5: tryCatchList(expr, classes, parentenv, handlers)
    4: tryCatch(res[[i]] <- install_remote(remotes[[i]], ...), error = function(e) {
           stop(remote_install_error(remotes[[i]], e))
       })
    3: install_remotes(remotes, auth_token = auth_token, host = host,
           dependencies = dependencies, upgrade = upgrade, force = force,
           quiet = quiet, build = build, build_opts = build_opts, build_manual = build_manual,
           build_vignettes = build_vignettes, repos = repos, type = type,
           ...)
    2: pkgbuild::with_build_tools({
           ellipsis::check_dots_used(action = getOption("devtools.ellipsis_action",
               rlang::warn))
           {
               remotes <- lapply(repo, github_remote, ref = ref, subdir = subdir,
                   auth_token = auth_token, host = host)
               install_remotes(remotes, auth_token = auth_token, host = host,
                   dependencies = dependencies, upgrade = upgrade, force = force,
                   quiet = quiet, build = build, build_opts = build_opts,
                   build_manual = build_manual, build_vignettes = build_vignettes,
                   repos = repos, type = type, ...)
           }
       }, required = FALSE)
    1: devtools::install_github("satijalab/seurat-data")