### PR TITLE
Remove warning

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -376,7 +376,7 @@ UpdateManifest <- function() {
           )
         }
         # Assemble the information
-        if (is.na(desc)) {
+        if (all(is.na(desc))) {
           desc <- c(
             'Dataset' = dataset,
             'Version' = pkg[['Version']],


### PR DESCRIPTION
When loading SeuratData:

```
library(SeuratData)
```

A series of warnings are logged, also reported in #41.  This is a simple proposal to remove them.