### PR TITLE
Add Seurat as dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,8 @@ Imports:
     rappdirs,
     stats,
     utils,
-    SeuratObject (>= 5.0.0)
+    SeuratObject (>= 5.0.0),
+    Seurat
 Collate:
     'zzz.R'
     'seurat_data.R'


### PR DESCRIPTION
Hello,

This package loads Seurat::LoadAnnoyIndex:

https://github.com/satijalab/seurat-data/blob/4dc08e022f51c324bc7bf785b1b5771d2742701d/R/seurat_data.R#L302

but it doesnt declare Seurat as a dependency in DESCRIPTION. This is a problem for packages like pak, which try to bundle/build in dependency order. 

It seems unlikely anyone is using seurat-data without also using Seurat. It is possible to declare this dependency?